### PR TITLE
Fix Extensions rendering

### DIFF
--- a/pages/pages.json
+++ b/pages/pages.json
@@ -8,7 +8,6 @@
       "path": "/legacy-extensions/orderplaced",
       "disableExternals": ["tachyons", "rc.js"]
     },
-
     "checkout-render": {
       "path": "/checkout-render"
     }
@@ -26,7 +25,6 @@
     "orderplaced/pixels": {
       "component": "vtex.render-runtime/ExtensionContainer"
     },
-
     "checkout-render": {
       "component": "index"
     },

--- a/react/core/HtmlPageBuilder.tsx
+++ b/react/core/HtmlPageBuilder.tsx
@@ -59,7 +59,7 @@ class HtmlPageBuilder {
   public getBody() {
     return (
       <Fragment>
-        <div dangerouslySetInnerHTML={{__html: this.body}}></div>
+        <div dangerouslySetInnerHTML={ { __html: this.body } } />
         { this.getBodyScripts() }
       </Fragment>
     )

--- a/react/core/scripts.tsx
+++ b/react/core/scripts.tsx
@@ -1,23 +1,44 @@
-const extensionLoaderScript = '\n\
+const createRenderLoaderPromise = '\n\
   (function(global) {\n\
     global.vtex.renderLoaderPromise = new Promise(function(resolve, reject) {\n\
       document.addEventListener("DOMContentLoaded", resolve);\n\
     });\n\
+  })(this);\n\
+'
+
+const defineRenderRuntimeAndRenderLoader = '\n\
+  (function(global) {\n\
     global.vtex.renderLoaderPromise.then(function() {\n\
       global.vtex.renderRuntime = global.__RUNTIME__;\n\
       global.vtex.renderLoader = {\n\
-        render: function(extension, element, props = {}) {\n\
+        render: function(extensionName, htmlElement, props = {}) {\n\
+          originalExtensionName = extensionName.replace(\'checkout/\', \'checkout-render/\');\n\
           const runtime = global[`__RENDER_${global.__RUNTIME__.renderMajor}_RUNTIME__`];\n\
-          runtime.renderExtension(extension, element, props)\n\
-        },\n\
-        update: function() {\n\
-  \n\
+          runtime.renderExtension(originalExtensionName, htmlElement, props);\n\
         }\n\
-      }\n\
+      };\n\
     });\n\
-  })(this)\n\
+  })(this);\n\
 '
 
+const changeRenderExtensionsKeys = '\n\
+  (function(global) {\n\
+    global.vtex.renderLoaderPromise.then(function() {\n\
+      const extensionsRenamed = {};\n\
+      Object.keys(global.vtex.renderRuntime.extensions).forEach((extensionName) => {\n\
+        extensionsRenamed[extensionName.replace(\'checkout-render/\', \'checkout/\')] = global.vtex.renderRuntime.extensions[extensionName];\n\
+      });\n\
+      global.vtex.renderRuntime.extensions = extensionsRenamed;\n\
+    });\n\
+  })(this);\n\
+'
+
+const extensionLoaderScript = (
+  createRenderLoaderPromise
+  + defineRenderRuntimeAndRenderLoader
+  + changeRenderExtensionsKeys
+)
+
 export {
-  extensionLoaderScript
+  extensionLoaderScript,
 }


### PR DESCRIPTION
  The current javascript code for checkout searches for extensions named `checkout/*`. They are not present, since the page being rendered is `checkout-render`. A workaround is to rename the keys on `vtex.renderRuntime.extensions` from `checkout-render/*` to `checkout/*`, so that the current checkout javascript successfully requests for extensions rendering.
  The method call to render the extension has to be made with the original extension name, so the `extensionName`, containing now something like `checkout/*`, has to be changed to `checkout-render/*`.