### PR TITLE
Add drawer implementation for mobile devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Implementation for the drawer and items summary in mobile devices.
+
 ## [2.3.0] - 2020-03-11
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -5,9 +5,7 @@
   "title": "Checkout UI",
   "description": "Checkout UI for the Store Framework",
   "defaultLocale": "pt-BR",
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "builders": {
     "assets": "0.x",
     "docs": "0.x",
@@ -19,6 +17,7 @@
   },
   "mustUpdateAt": "2019-04-02",
   "dependencies": {
+    "vtex.css-handles": "0.x",
     "vtex.checkout-cart": "0.x",
     "vtex.checkout-identification": "0.x",
     "vtex.checkout-step-group": "0.x",
@@ -33,6 +32,7 @@
     "vtex.store-components": "3.x",
     "vtex.product-list": "0.x",
     "vtex.rich-text": "0.x",
+    "vtex.store-drawer": "0.x",
     "vtex.store-header": "2.x",
     "vtex.responsive-layout": "0.x",
     "vtex.store-footer": "2.x",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,5 +1,6 @@
 {
   "store/place-order-button": "Place Order",
   "store/checkout-product-count": "{quantity, plural, one {# product} other {# products}}",
-  "store/edit-cart-label": "Edit Cart"
+  "store/edit-cart-label": "Edit Cart",
+  "store/view-cart-label": "View Cart"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,5 +1,6 @@
 {
   "store/place-order-button": "Finalizar Compra",
   "store/checkout-product-count": "{quantity, plural, one {# producto} other {# productos}}",
-  "store/edit-cart-label": "Editar Carrito"
+  "store/edit-cart-label": "Editar Carrito",
+  "store/view-cart-label": "Ver Carrito"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,5 +1,6 @@
 {
   "store/place-order-button": "Fechar Pedido",
   "store/checkout-product-count": "{quantity, plural, one {# produto} other {# produtos}}",
-  "store/edit-cart-label": "Editar Carrinho"
+  "store/edit-cart-label": "Editar Carrinho",
+  "store/view-cart-label": "Ver Carrinho"
 }

--- a/node/package.json
+++ b/node/package.json
@@ -32,7 +32,7 @@
     "vtex.rich-text": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rich-text@0.8.2/public/@types/vtex.rich-text",
     "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.90.2/public/@types/vtex.store",
     "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.105.1/public/_types/react",
-    "vtex.store-drawer": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.8.1/public/@types/vtex.store-drawer",
+    "vtex.store-drawer": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.9.0/public/@types/vtex.store-drawer",
     "vtex.store-footer": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-footer@2.19.2/public/@types/vtex.store-footer",
     "vtex.store-header": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-header@2.25.3/public/_types/react",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.15/public/@types/vtex.styleguide"

--- a/node/package.json
+++ b/node/package.json
@@ -15,12 +15,13 @@
     "@types/ramda": "types/npm-ramda#dist",
     "@vtex/api": "^3.72.0",
     "typescript": "3.8.3",
-    "vtex.checkout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout@2.2.0/public/@types/vtex.checkout",
+    "vtex.checkout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout@2.3.0/public/@types/vtex.checkout",
     "vtex.checkout-cart": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-cart@0.24.4/public/@types/vtex.checkout-cart",
     "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.3.0/public/@types/vtex.checkout-container",
     "vtex.checkout-identification": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-identification@0.1.1/public/@types/vtex.checkout-identification",
-    "vtex.checkout-step-group": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-step-group@0.4.0/public/@types/vtex.checkout-step-group",
+    "vtex.checkout-step-group": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-step-group@0.5.0/public/@types/vtex.checkout-step-group",
     "vtex.checkout-summary": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-summary@0.14.1/public/@types/vtex.checkout-summary",
+    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles",
     "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.14.0/public/@types/vtex.flex-layout",
     "vtex.order-coupon": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-coupon@0.7.1/public/@types/vtex.order-coupon",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.2/public/@types/vtex.order-manager",
@@ -31,8 +32,9 @@
     "vtex.rich-text": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rich-text@0.8.2/public/@types/vtex.rich-text",
     "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.90.2/public/@types/vtex.store",
     "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.105.1/public/_types/react",
+    "vtex.store-drawer": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.8.1/public/@types/vtex.store-drawer",
     "vtex.store-footer": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-footer@2.19.2/public/@types/vtex.store-footer",
     "vtex.store-header": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-header@2.25.3/public/_types/react",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.14/public/@types/vtex.styleguide"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.15/public/@types/vtex.styleguide"
   }
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1521,9 +1521,9 @@ uuid@^3.1.0:
   version "0.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.105.1/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
-"vtex.store-drawer@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.8.1/public/@types/vtex.store-drawer":
-  version "0.8.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.8.1/public/@types/vtex.store-drawer#1abf2b50cf902fc1121989655de851f2fd13c78c"
+"vtex.store-drawer@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.9.0/public/@types/vtex.store-drawer":
+  version "0.9.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.9.0/public/@types/vtex.store-drawer#f01bd51690f43c47f3a136e959ce338aecde5335"
 
 "vtex.store-footer@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-footer@2.19.2/public/@types/vtex.store-footer":
   version "2.19.2"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1469,17 +1469,21 @@ uuid@^3.1.0:
   version "0.1.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-identification@0.1.1/public/@types/vtex.checkout-identification#2183ec6fbc7942a96eac13c88a11d7aa590baf7d"
 
-"vtex.checkout-step-group@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-step-group@0.4.0/public/@types/vtex.checkout-step-group":
-  version "0.4.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-step-group@0.4.0/public/@types/vtex.checkout-step-group#2b042a7e6c0330f5fabd4e206342c5213c9f19a1"
+"vtex.checkout-step-group@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-step-group@0.5.0/public/@types/vtex.checkout-step-group":
+  version "0.5.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-step-group@0.5.0/public/@types/vtex.checkout-step-group#c022b0ef1e8d5e597b783e242151b3c6667219d2"
 
 "vtex.checkout-summary@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-summary@0.14.1/public/@types/vtex.checkout-summary":
   version "0.14.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-summary@0.14.1/public/@types/vtex.checkout-summary#19e78cac4ab10984b5527685b580c5160eabe42d"
 
-"vtex.checkout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout@2.2.0/public/@types/vtex.checkout":
+"vtex.checkout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout@2.3.0/public/@types/vtex.checkout":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout@2.2.0/public/@types/vtex.checkout#c6e0c34f23d0316cb04a163a13637118285a472b"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout@2.3.0/public/@types/vtex.checkout#b96253808bb19e040b9f391449bcc6c9d01baf19"
+
+"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles":
+  version "0.4.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles#62ee61d1bb9efdc919e5cf4bb44fabcf9050d255"
 
 "vtex.flex-layout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.14.0/public/@types/vtex.flex-layout":
   version "0.14.0"
@@ -1517,6 +1521,10 @@ uuid@^3.1.0:
   version "0.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.105.1/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
+"vtex.store-drawer@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.8.1/public/@types/vtex.store-drawer":
+  version "0.8.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.8.1/public/@types/vtex.store-drawer#1abf2b50cf902fc1121989655de851f2fd13c78c"
+
 "vtex.store-footer@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-footer@2.19.2/public/@types/vtex.store-footer":
   version "2.19.2"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-footer@2.19.2/public/@types/vtex.store-footer#a1b38a015696f3556f1da62b2e2e6cf5f2792958"
@@ -1529,9 +1537,9 @@ uuid@^3.1.0:
   version "2.90.2"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.90.2/public/@types/vtex.store#7988258e70743097b38feab222fc07648c482bbd"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.14/public/@types/vtex.styleguide":
-  version "9.112.14"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.14/public/@types/vtex.styleguide#3ad332c14335505fe50545af11331a2d54e681ae"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.15/public/@types/vtex.styleguide":
+  version "9.112.15"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.15/public/@types/vtex.styleguide#1859832d974e0b0b82dff8ed086f005907058dda"
 
 wrappy@1:
   version "1.0.2"

--- a/react/ProductCounter.tsx
+++ b/react/ProductCounter.tsx
@@ -8,7 +8,11 @@ const messages = defineMessages({
   },
 })
 
-const ProductCounter: React.FC = () => {
+interface Props {
+  type?: 'simple' | 'full'
+}
+
+const ProductCounter: React.FC<Props> = ({ type = 'full' }) => {
   const {
     orderForm: { items },
   } = useOrderForm()
@@ -17,10 +21,14 @@ const ProductCounter: React.FC = () => {
 
   return (
     <p className="c-muted-1 t-body b ma0">
-      <FormattedMessage
-        {...messages.productCount}
-        values={{ quantity: productCount }}
-      />
+      {type === 'full' ? (
+        <FormattedMessage
+          {...messages.productCount}
+          values={{ quantity: productCount }}
+        />
+      ) : (
+        productCount
+      )}
     </p>
   )
 }

--- a/react/SummaryWrapper.tsx
+++ b/react/SummaryWrapper.tsx
@@ -3,7 +3,11 @@ import { ExtensionPoint } from 'vtex.render-runtime'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
 import { useOrderCoupon } from 'vtex.order-coupon/OrderCoupon'
 
-const SummaryWrapper: React.FC = () => {
+interface Props {
+  lean?: boolean
+}
+
+const SummaryWrapper: React.FC<Props> = ({ lean = false }) => {
   const {
     orderForm: {
       totalizers,
@@ -15,7 +19,7 @@ const SummaryWrapper: React.FC = () => {
   const { insertCoupon } = useOrderCoupon()
 
   return (
-    <div className="mh8-m mh0-l pt6 pt0-l bt b--muted-4 bn-l">
+    <div className={lean ? '' : 'mh8-m mh0-l pt6 pt0-l bt b--muted-4 bn-l'}>
       <ExtensionPoint
         id="checkout-summary"
         blockProps={{

--- a/react/ViewCartLabel.tsx
+++ b/react/ViewCartLabel.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { FormattedMessage } from 'react-intl'
+import { useCssHandles } from 'vtex.css-handles'
+
+const CSS_HANDLES = ['viewCartLabel'] as const
+
+const ViewCartLabel: React.FC = () => {
+  const handles = useCssHandles(CSS_HANDLES)
+
+  return (
+    <span className={`c-muted-1 t-body f6 fw6 ${handles.viewCartLabel}`}>
+      <FormattedMessage id="store/view-cart-label" />
+    </span>
+  )
+}
+
+export default ViewCartLabel

--- a/react/package.json
+++ b/react/package.json
@@ -42,7 +42,7 @@
     "vtex.rich-text": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rich-text@0.8.2/public/@types/vtex.rich-text",
     "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.90.2/public/@types/vtex.store",
     "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.105.1/public/_types/react",
-    "vtex.store-drawer": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.8.1/public/@types/vtex.store-drawer",
+    "vtex.store-drawer": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.9.0/public/@types/vtex.store-drawer",
     "vtex.store-footer": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-footer@2.19.2/public/@types/vtex.store-footer",
     "vtex.store-header": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-header@2.25.3/public/_types/react",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.15/public/@types/vtex.styleguide"

--- a/react/package.json
+++ b/react/package.json
@@ -7,7 +7,6 @@
     "lint": "tsc --noEmit && eslint --ext ts,tsx ."
   },
   "dependencies": {
-    "@vtex/css-handles": "^1.0.0",
     "classnames": "^2.2.6",
     "ramda": "^0.26.1",
     "react": "^16.8.3",
@@ -29,21 +28,23 @@
     "vtex.checkout-cart": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-cart@0.24.4/public/@types/vtex.checkout-cart",
     "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.3.0/public/@types/vtex.checkout-container",
     "vtex.checkout-identification": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-identification@0.1.1/public/@types/vtex.checkout-identification",
-    "vtex.checkout-step-group": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-step-group@0.4.0/public/@types/vtex.checkout-step-group",
+    "vtex.checkout-step-group": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-step-group@0.5.0/public/@types/vtex.checkout-step-group",
     "vtex.checkout-summary": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-summary@0.14.1/public/@types/vtex.checkout-summary",
+    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles",
     "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.14.0/public/@types/vtex.flex-layout",
     "vtex.order-coupon": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-coupon@0.7.1/public/@types/vtex.order-coupon",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.2/public/@types/vtex.order-manager",
     "vtex.pixel-interfaces": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-interfaces@1.1.1/public/_types/react",
     "vtex.pixel-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.1.4/public/@types/vtex.pixel-manager",
     "vtex.product-list": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-list@0.19.0/public/@types/vtex.product-list",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.0/public/@types/vtex.render-runtime",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.1/public/@types/vtex.render-runtime",
     "vtex.responsive-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-layout@0.1.2/public/@types/vtex.responsive-layout",
     "vtex.rich-text": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rich-text@0.8.2/public/@types/vtex.rich-text",
     "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.90.2/public/@types/vtex.store",
     "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.105.1/public/_types/react",
+    "vtex.store-drawer": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.8.1/public/@types/vtex.store-drawer",
     "vtex.store-footer": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-footer@2.19.2/public/@types/vtex.store-footer",
     "vtex.store-header": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-header@2.25.3/public/_types/react",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.14/public/@types/vtex.styleguide"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.15/public/@types/vtex.styleguide"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4826,9 +4826,9 @@ verror@1.10.0:
   version "0.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.105.1/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
-"vtex.store-drawer@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.8.1/public/@types/vtex.store-drawer":
-  version "0.8.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.8.1/public/@types/vtex.store-drawer#1abf2b50cf902fc1121989655de851f2fd13c78c"
+"vtex.store-drawer@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.9.0/public/@types/vtex.store-drawer":
+  version "0.9.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.9.0/public/@types/vtex.store-drawer#f01bd51690f43c47f3a136e959ce338aecde5335"
 
 "vtex.store-footer@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-footer@2.19.2/public/@types/vtex.store-footer":
   version "2.19.2"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1050,11 +1050,6 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vtex/css-handles@^1.0.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@vtex/css-handles/-/css-handles-1.1.0.tgz#c49998230e7b1576bef4ea6125471137a54c6c86"
-  integrity sha512-GP5ONxBimQoKRIW8WjUCI5/HU13JdMTxPw1aoumWcDv3ycUu13IR8HzzIuTM+iFZE9ctvGZfVCq9FXqQ747yNw==
-
 "@vtex/test-tools@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@vtex/test-tools/-/test-tools-0.2.0.tgz#3bb202a918bd60201ae23c55901d7308e638743c"
@@ -4779,13 +4774,17 @@ verror@1.10.0:
   version "0.1.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-identification@0.1.1/public/@types/vtex.checkout-identification#2183ec6fbc7942a96eac13c88a11d7aa590baf7d"
 
-"vtex.checkout-step-group@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-step-group@0.4.0/public/@types/vtex.checkout-step-group":
-  version "0.4.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-step-group@0.4.0/public/@types/vtex.checkout-step-group#2b042a7e6c0330f5fabd4e206342c5213c9f19a1"
+"vtex.checkout-step-group@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-step-group@0.5.0/public/@types/vtex.checkout-step-group":
+  version "0.5.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-step-group@0.5.0/public/@types/vtex.checkout-step-group#c022b0ef1e8d5e597b783e242151b3c6667219d2"
 
 "vtex.checkout-summary@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-summary@0.14.1/public/@types/vtex.checkout-summary":
   version "0.14.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-summary@0.14.1/public/@types/vtex.checkout-summary#19e78cac4ab10984b5527685b580c5160eabe42d"
+
+"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles":
+  version "0.4.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles#62ee61d1bb9efdc919e5cf4bb44fabcf9050d255"
 
 "vtex.flex-layout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.14.0/public/@types/vtex.flex-layout":
   version "0.14.0"
@@ -4811,9 +4810,9 @@ verror@1.10.0:
   version "0.19.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-list@0.19.0/public/@types/vtex.product-list#5a0d5d0bc159d88dfc3aa7cef9515f8943b62fc2"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.0/public/@types/vtex.render-runtime":
-  version "8.95.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.0/public/@types/vtex.render-runtime#83fadce267c67a81eb99f4cc77afbd54d4c9b650"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.1/public/@types/vtex.render-runtime":
+  version "8.95.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.1/public/@types/vtex.render-runtime#3aae291d0cd239d3059ea8ae8c3c2800ce36d22f"
 
 "vtex.responsive-layout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-layout@0.1.2/public/@types/vtex.responsive-layout":
   version "0.1.2"
@@ -4827,6 +4826,10 @@ verror@1.10.0:
   version "0.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.105.1/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
+"vtex.store-drawer@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.8.1/public/@types/vtex.store-drawer":
+  version "0.8.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.8.1/public/@types/vtex.store-drawer#1abf2b50cf902fc1121989655de851f2fd13c78c"
+
 "vtex.store-footer@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-footer@2.19.2/public/@types/vtex.store-footer":
   version "2.19.2"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-footer@2.19.2/public/@types/vtex.store-footer#a1b38a015696f3556f1da62b2e2e6cf5f2792958"
@@ -4839,9 +4842,9 @@ verror@1.10.0:
   version "2.90.2"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.90.2/public/@types/vtex.store#7988258e70743097b38feab222fc07648c482bbd"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.14/public/@types/vtex.styleguide":
-  version "9.112.14"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.14/public/@types/vtex.styleguide#3ad332c14335505fe50545af11331a2d54e681ae"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.15/public/@types/vtex.styleguide":
+  version "9.112.15"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.15/public/@types/vtex.styleguide#1859832d974e0b0b82dff8ed086f005907058dda"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"

--- a/store/blocks/common.json
+++ b/store/blocks/common.json
@@ -9,5 +9,10 @@
       "src": "assets/logo.png",
       "maxHeight": 40
     }
+  },
+  "product-counter#simple": {
+    "props": {
+      "type": "simple"
+    }
   }
 }

--- a/store/blocks/container-desktop.json
+++ b/store/blocks/container-desktop.json
@@ -2,7 +2,7 @@
   "flex-layout.row#container-desktop": {
     "children": [
       "flex-layout.col#checkout-desktop",
-      "flex-layout.col#items-summary"
+      "flex-layout.col#items-summary-desktop"
     ],
     "props": {
       "blockClass": "checkoutContainer",

--- a/store/blocks/container-mobile.json
+++ b/store/blocks/container-mobile.json
@@ -9,7 +9,7 @@
 
   "flex-layout.col#checkout-mobile": {
     "children": [
-      "image#logo",
+      "flex-layout.row#checkout-mobile-header",
       "checkout-step-group#checkout-mobile",
       "summary-wrapper",
       "place-order",
@@ -20,6 +20,55 @@
       "blockClass": "checkoutColumnMobile"
     }
   },
+
+  "flex-layout.row#checkout-mobile-header": {
+    "children": ["image#logo", "drawer#cart-drawer"],
+    "props": {
+      "preventHorizontalStretch": true,
+      "preserveLayoutOnMobile": true,
+      "blockClass": "checkoutMobileHeader"
+    }
+  },
+
+  "drawer#cart-drawer": {
+    "children": ["flex-layout.col#items-summary-mobile"],
+    "blocks": [
+      "drawer-trigger#checkout-drawer",
+      "drawer-header#checkout-drawer-header"
+    ],
+    "props": {
+      "slideDirection": "rightToLeft",
+      "blockClass": "checkout"
+    }
+  },
+  "drawer-trigger#checkout-drawer": {
+    "children": ["view-cart-label"]
+  },
+  "drawer-header#checkout-drawer-header": {
+    "children": ["flex-layout.row#checkout-drawer-header"],
+    "props": {
+      "blockClass": "checkout"
+    }
+  },
+  "flex-layout.row#checkout-drawer-header": {
+    "children": [
+      "flex-layout.row#drawer-items-meta",
+      "drawer-close-button#checkout-drawer"
+    ],
+    "props": {
+      "preserveLayoutOnMobile": true,
+      "preventHorizontalStretch": true,
+      "blockClass": "checkoutDrawerHeader",
+      "paddingBottom": 5
+    }
+  },
+  "drawer-close-button#checkout-drawer": {
+    "props": {
+      "size": 24,
+      "blockClass": "checkoutDrawer"
+    }
+  },
+
   "checkout-step-group#checkout-mobile": {
     "children": ["profile-step", "shipping-step", "payment-step"],
     "props": {

--- a/store/blocks/items-summary.json
+++ b/store/blocks/items-summary.json
@@ -1,5 +1,5 @@
 {
-  "flex-layout.col#items-summary": {
+  "flex-layout.col#items-summary-desktop": {
     "children": [
       "flex-layout.row#items-meta",
       "divider#horizontal",
@@ -12,22 +12,54 @@
       "paddingLeft": 6
     }
   },
+  "flex-layout.col#items-summary-mobile": {
+    "children": [
+      "divider#horizontal",
+      "checkout-product-list",
+      "summary-wrapper#drawer"
+    ],
+    "props": {
+      "blockClass": "itemsSummary",
+      "preventVerticalStretch": true
+    }
+  },
   "flex-layout.row#items-meta": {
     "children": ["product-counter", "back-to-cart-button"],
     "props": {
       "paddingTop": 7,
       "paddingBottom": 5,
       "preventHorizontalStretch": true,
+      "preserveLayoutOnMobile": true,
       "blockClass": "itemsSummaryMeta"
+    }
+  },
+  "flex-layout.row#drawer-items-meta": {
+    "children": ["product-counter", "back-to-cart-button"],
+    "props": {
+      "preventHorizontalStretch": true,
+      "preserveLayoutOnMobile": true,
+      "blockClass": "itemsSummaryDrawerMeta"
     }
   },
   "summary-wrapper": {
     "blocks": ["checkout-summary#checkout"]
   },
+  "summary-wrapper#drawer": {
+    "blocks": ["checkout-summary#checkout-drawer"],
+    "props": {
+      "lean": true
+    }
+  },
   "checkout-summary#checkout": {
     "children": ["flex-layout.row#summary-coupon", "summary-totalizers"],
     "props": {
       "blockClass": "checkout"
+    }
+  },
+  "checkout-summary#checkout-drawer": {
+    "children": ["flex-layout.row#summary-coupon", "summary-totalizers"],
+    "props": {
+      "blockClass": "checkoutDrawer"
     }
   },
   "flex-layout.row#summary-coupon": {

--- a/store/blocks/product-list.json
+++ b/store/blocks/product-list.json
@@ -48,6 +48,7 @@
     "props": {
       "marginTop": 5,
       "preventHorizontalStretch": true,
+      "preserveLayoutOnMobile": true,
       "blockClass": "checkoutItemPriceWrapper"
     }
   },

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -57,5 +57,8 @@
   "summary-wrapper": {
     "component": "SummaryWrapper",
     "allowed": ["checkout-summary"]
+  },
+  "view-cart-label": {
+    "component": "ViewCartLabel"
   }
 }

--- a/styles/css/vtex.checkout-summary.css
+++ b/styles/css/vtex.checkout-summary.css
@@ -1,3 +1,8 @@
+.summaryTitle--checkoutDrawer {
+  display: none;
+  margin: 0;
+}
+
 @media only screen and (min-width: 64em) {
   .summaryTitle--checkout {
     display: none;

--- a/styles/css/vtex.flex-layout.css
+++ b/styles/css/vtex.flex-layout.css
@@ -38,10 +38,7 @@
 
 .flexCol--itemsSummary {
   background-color: #f2f4f5;
-}
-
-.flexRowContent--footerText {
-  justify-content: space-between;
+  height: 100%;
 }
 
 .flexRowContent--itemsSummaryMeta {
@@ -49,10 +46,23 @@
   align-items: center;
 }
 
-.flexRowContent--checkoutItemPriceWrapper {
-  justify-content: space-between;
+.flexRowContent--itemsSummaryDrawerMeta {
+  align-items: center;
+  height: 100%;
 }
 
+.flexRowContent--itemsSummaryDrawerMeta :global(.vtex-button) {
+  margin-left: .5rem;
+}
+
+.flexRow--checkoutDrawerHeader {
+  width: 100%;
+}
+
+.flexRowContent--footerText ,
+.flexRowContent--checkoutItemPriceWrapper,
+.flexRowContent--checkoutDrawerHeader,
 .flexRowContent--checkoutMobileHeader {
   justify-content: space-between;
 }
+

--- a/styles/css/vtex.flex-layout.css
+++ b/styles/css/vtex.flex-layout.css
@@ -52,3 +52,7 @@
 .flexRowContent--checkoutItemPriceWrapper {
   justify-content: space-between;
 }
+
+.flexRowContent--checkoutMobileHeader {
+  justify-content: space-between;
+}

--- a/styles/css/vtex.store-drawer.css
+++ b/styles/css/vtex.store-drawer.css
@@ -1,0 +1,26 @@
+.drawer--checkout,
+.drawerHeader--checkout {
+  background-color: #f2f4f5;
+}
+
+.drawer--checkout {
+  padding: 1.5rem 1rem;
+}
+
+@media only screen and (min-width: 40em) {
+  .drawer--checkout {
+    padding: 2rem 1.5rem;
+  }
+}
+
+.drawerHeader--checkout {
+  overflow: hidden;
+}
+
+.closeIconButton--checkoutDrawer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #727273;
+  margin: -.75rem;
+}


### PR DESCRIPTION
#### What problem is this solving?
Adds the drawer block as defined in Figma. This drawer reuses almost all the specification of the `items-summary` that the desktop already uses, but needed a few refinements due to the way the drawer app handles it's "header" (which contains the close button) and the content of the drawer. Also some adjustments were needed in the `SummaryWrapper` component so it won't have margins and paddings inside the drawer, which differs from its appearance in the page body.

[Related clubhouse story](https://app.clubhouse.io/vtex/story/33452/implementa%C3%A7%C3%A3o-da-drawer-no-checkout-mobile)

#### How should this be manually tested?
[Workspace](https://chkio--checkoutio.myvtex.com/checkout)

#### Checklist/Reminders

- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).

#### Screenshots or example usage
![checkout drawer](https://user-images.githubusercontent.com/10223856/76530719-e88ef400-6452-11ea-88e4-b1d4eaae4e1b.gif)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->