### PR TITLE
Use custom container in topmost flex-layout

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @vtex-apps/checkout-ui

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Use custom container measurements in the container flex-layout.
+
 ## [2.4.0] - 2020-03-13
 
 ### Added

--- a/store/blocks/container-desktop.json
+++ b/store/blocks/container-desktop.json
@@ -6,7 +6,8 @@
     ],
     "props": {
       "blockClass": "checkoutContainer",
-      "preserveLayoutOnMobile": true
+      "preserveLayoutOnMobile": true,
+      "fullWidth": true
     }
   },
   "flex-layout.col#checkout-desktop": {

--- a/store/blocks/container-mobile.json
+++ b/store/blocks/container-mobile.json
@@ -2,8 +2,9 @@
   "flex-layout.row#container-mobile": {
     "children": ["flex-layout.col#checkout-mobile"],
     "props": {
-      "blockClass": "checkoutContainerMobile",
-      "paddingTop": 6
+      "blockClass": "checkoutContainer",
+      "paddingTop": 6,
+      "fullWidth": true
     }
   },
 

--- a/styles/css/vtex.flex-layout.css
+++ b/styles/css/vtex.flex-layout.css
@@ -5,8 +5,7 @@
   justify-content: center;
 }
 
-.flexRowContent--checkoutContainer,
-.flexRowContent--checkoutContainerMobile {
+.flexRowContent--checkoutContainer {
   min-height: 100vh;
   position: relative;
 }
@@ -19,6 +18,12 @@
   left: 100%;
   width: calc((100vw - 100%) / 2);
   height: 100%;
+}
+
+@media only screen and (max-width: 64em) {
+  .flexRowContent--checkoutContainer::after {
+    display: none;
+  }
 }
 
 .flexCol--checkoutColumn {
@@ -66,3 +71,58 @@
   justify-content: space-between;
 }
 
+/* Checkout Container */
+
+.flexRow--checkoutContainer {
+  margin: 0 1em;
+}
+
+/* S */
+@media screen and (min-width: 39em) and (max-width: 40em) {
+  .flexRow--checkoutContainer {
+    margin: 0 auto;
+    width: 37em;
+  }
+}
+
+/* M */
+@media screen and (min-width: 40em) and (max-width: 61em) {
+  .flexRow--checkoutContainer {
+    margin: 0 1.5em;
+  }
+}
+
+@media screen and (min-width: 61em) and (max-width: 64em) {
+  .flexRow--checkoutContainer {
+    margin: 0 auto;
+    width: 58em;
+  }
+}
+
+/* L */
+@media screen and (min-width: 64em) and (max-width: 78em) {
+  .flexRow--checkoutContainer {
+    margin: 0 3em;
+  }
+}
+
+@media screen and (min-width: 78em) and (max-width: 80em) {
+  .flexRow--checkoutContainer {
+    margin: 0 auto;
+    width: 72em;
+  }
+}
+
+/* XL */
+@media screen and (min-width: 80em) and (max-width: 104em) {
+  .flexRow--checkoutContainer {
+    margin: 0 4em;
+  }
+}
+
+@media screen and (min-width: 104em) {
+  .flexRow--checkoutContainer {
+    margin: 0 auto;
+    width: 96em;
+  }
+}

--- a/styles/css/vtex.store-footer.css
+++ b/styles/css/vtex.store-footer.css
@@ -4,7 +4,21 @@
 }
 
 .footerLayout--checkoutFooterMobile {
-  margin: 1rem -.5rem 0;
+  margin: 1rem -1rem 0;
   padding: 1.5rem 1rem;
   background-color: #f2f4f5;
+}
+
+@media only screen and (min-width: 40em) {
+  .footerLayout--checkoutFooterMobile {
+    margin-left: -1.5rem;
+    margin-right: -1.5rem;
+  }
+}
+
+@media only screen and (min-width: 61em) {
+  .footerLayout--checkoutFooterMobile {
+    margin-left: calc((100% - 100vw) / 2);
+    margin-right: calc((100% - 100vw) / 2);
+  }
 }

--- a/styles/css/vtex.store-footer.css
+++ b/styles/css/vtex.store-footer.css
@@ -13,6 +13,7 @@
   .footerLayout--checkoutFooterMobile {
     margin-left: -1.5rem;
     margin-right: -1.5rem;
+    padding: 1.5rem 1.75rem;
   }
 }
 


### PR DESCRIPTION
#### What problem is this solving?
The container used by default in `flex-layout` wasn't responsive enough for our needs, so we needed to make a custom.

#### How should this be manually tested?
[Workspace](https://chkio--checkoutio.myvtex.com/checkout/#/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![Screen Shot 2020-03-23 at 10 52 34](https://user-images.githubusercontent.com/10223856/77323731-76d96480-6cf4-11ea-9ba2-0382bfbbbad8.png)
> Desktop

![Screenshot_2020-03-23 https chkio--checkoutio myvtex com(1)](https://user-images.githubusercontent.com/10223856/77323896-b902a600-6cf4-11ea-8db4-9efadc5a8461.png)
> Tablet

![Screenshot_2020-03-23 https chkio--checkoutio myvtex com](https://user-images.githubusercontent.com/10223856/77323899-bacc6980-6cf4-11ea-97d1-736ba7746231.png)
> Mobile

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->