### PR TITLE
Update to hide review info while user isn't in review route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated place order button to only appear on review route.
 
 ## [2.4.3] - 2020-05-06
-
 ### Added
-
 - Animation to items summary.
 
 ### Fixed
-
 - Layout overflow and a one pixel line right beside the summary.
 
 ## [2.4.2] - 2020-04-22
-
 ### Added
-
 - Sales disclaimer in footer.
 - View cart button in summary review step.
 
 ### Fixed
-
 - Footer alignment on mobile.
 - Alignment of open cart button in header.
 - Sidebar padding in bigger breakpoints.
@@ -33,61 +29,42 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ratio width between checkout and sidebar on desktop.
 
 ## [2.4.1] - 2020-03-23
-
 ### Changed
-
 - Use custom container measurements in the container flex-layout.
 
 ## [2.4.0] - 2020-03-13
-
 ### Added
-
 - Implementation for the drawer and items summary in mobile devices.
 
 ## [2.3.0] - 2020-03-11
-
 ### Added
-
 - Mobile layout for checkout page.
 
 ## [2.2.0] - 2020-03-10
-
 ### Added
-
 - Basic layout for new checkout page.
 
 ## [2.1.0] - 2020-03-03
-
 ### Added
-
 - Route `/checkout/identification` to render the new identification page.
 - Dependency `vtex.checkout-identification`.
 
 ## [2.0.0] - 2020-02-27
-
 ### Added
-
 - Route `/checkout` to point to the new Checkout implementation.
 - Store interface `store.checkout.container` to render the new route.
 
 ### Changed
-
 - Upgrade to node builder 4.x.
 
 ## [1.1.0] - 2019-10-31
-
 ### Added
-
 - Route `/cart/add` that allows adding items to cart via query string.
 
 ## [1.0.2] - 2019-10-25
-
 ### Added
-
 - Settings schema for checkout v6 to identify the new checkout is installed
 
 ## [1.0.1] - 2019-08-20
-
 ### Changed
-
 - App purpose to be new checkout main app.

--- a/react/ReviewContainer.tsx
+++ b/react/ReviewContainer.tsx
@@ -4,9 +4,9 @@ import { Router } from 'vtex.checkout-container'
 const REVIEW_ROUTE = '/'
 
 const ReviewContainer: React.FC = ({ children }) => {
-  const matches = !!Router.useRouteMatch(REVIEW_ROUTE)
+  const match = Router.useRouteMatch(REVIEW_ROUTE)
 
-  if (!matches) {
+  if (!match?.isExact) {
     return null
   }
 

--- a/react/ReviewContainer.tsx
+++ b/react/ReviewContainer.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Router } from 'vtex.checkout-container'
+
+const REVIEW_ROUTE = '/'
+
+const ReviewContainer: React.FC = ({ children }) => {
+  const matches = !!Router.useRouteMatch(REVIEW_ROUTE)
+
+  if (!matches) {
+    return null
+  }
+
+  return <>{children}</>
+}
+
+export default ReviewContainer

--- a/store/blocks/container-desktop.json
+++ b/store/blocks/container-desktop.json
@@ -14,7 +14,7 @@
     "children": [
       "image#logo",
       "checkout-step-group",
-      "place-order",
+      "review-container#desktop",
       "footer-layout#checkout"
     ],
     "props": {

--- a/store/blocks/container-mobile.json
+++ b/store/blocks/container-mobile.json
@@ -12,8 +12,7 @@
     "children": [
       "flex-layout.row#checkout-mobile-header",
       "checkout-step-group#checkout-mobile",
-      "summary-wrapper#review",
-      "place-order",
+      "review-container#mobile",
       "footer-layout#checkout-mobile"
     ],
     "props": {

--- a/store/blocks/review.json
+++ b/store/blocks/review.json
@@ -1,0 +1,8 @@
+{
+  "review-container#desktop": {
+    "children": ["place-order"]
+  },
+  "review-container#mobile": {
+    "children": ["summary-wrapper#review", "place-order"]
+  }
+}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -60,5 +60,9 @@
   },
   "view-cart-label": {
     "component": "ViewCartLabel"
+  },
+  "review-container": {
+    "component": "ReviewContainer",
+    "composition": "children"
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

This PR hides the review information (the place order button on desktop, and the totalizers on mobile) when the user isn't on the review route (which currently is `/`), so now the "Place Order" button won't be always rendered regardless of the route.

#### How should this be manually tested?
[Workspace](https://paymentio--checkoutio.myvtex.com/checkout/#/).

Test plan:

1. Try navigating between the steps, i.e., edit the profile or payment.
2. The place order button/totalizers shouldn't be displayed (only in the drawer).
3. Go back to the [review route](https://paymentio--checkoutio.myvtex.com/checkout/#/), and the informations should be displayed.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->