### PR TITLE
CHUI-68: Add support for payment methods without sensitive data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for payment methods without sensitive data.
 
 ## [2.5.0] - 2020-06-05
 ### Added

--- a/react/PlaceOrder.tsx
+++ b/react/PlaceOrder.tsx
@@ -116,7 +116,7 @@ const PlaceOrder: React.FC = () => {
       let redirectUrl
 
       if (hasSensitiveData) {
-        const { data } = await postRobot.send(
+        const { data: url } = await postRobot.send(
           cardFormIframe.contentWindow,
           'sendPayments',
           {
@@ -128,7 +128,7 @@ const PlaceOrder: React.FC = () => {
           }
         )
 
-        redirectUrl = data
+        redirectUrl = url
       } else {
         const paymentsResponse = await fetch(
           `${rootPath}/api/payments/pub/transactions/${transactionId}/payments?orderId=${orderGroupId}`,


### PR DESCRIPTION
#### What problem is this solving?

This PR adds support for payment methods that don't require sensitive data (don't use the PCI iframe) like Boleto.

#### How should this be manually tested?

[Workspace](https://boleto--checkoutio.myvtex.com/cart/add?sku=289&qty=1&seller=1).

Access the above workspace and try to place the order with the "Boleto" payment option.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->