### PR TITLE
Fix post-robot version @10.0.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Fixed `post-robot` package version at `10.0.35` to avoid issues with mismatching versions between different checkout apps.
 
 ## [2.6.0] - 2020-06-22
 ### Added

--- a/react/package.json
+++ b/react/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.6",
-    "post-robot": "^10.0.31",
+    "post-robot": "10.0.35",
     "ramda": "^0.26.1",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -3813,10 +3813,10 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
-post-robot@^10.0.31:
-  version "10.0.31"
-  resolved "https://registry.yarnpkg.com/post-robot/-/post-robot-10.0.31.tgz#167a6e57c48489f2600b038145cfce53be9163be"
-  integrity sha512-BIw0VCKRlugKYiRTiAYWS/g2/LYjoCfn/YHO9MKcrGGyeHqw1FBaFx4FTcYsTz5z8s6bJGlj6WynSEAe6uA5LA==
+post-robot@10.0.35:
+  version "10.0.35"
+  resolved "https://registry.yarnpkg.com/post-robot/-/post-robot-10.0.35.tgz#a3d865009d54b4c1562ab753f3d5a2a5c80f4ca3"
+  integrity sha512-4e+gzfaAqGMW2npJJAp9vJavfeGkoZAS+AzqdvTovzLaehN88y0KePsOAkYFzyU+wVd6biYvbB0VtBCtN6QGwA==
   dependencies:
     belter "^1.0.41"
     cross-domain-safe-weakmap "^1.0.1"


### PR DESCRIPTION
#### What problem is this solving?
Using different `post-robot` versions between the iFrame and the parent app causes issues such as the iFrame not loading. We are fixing this package's version at `10.0.35` across all checkout apps using it to avoid problems in the future.

#### How should this be manually tested?

Follow the test plan of https://github.com/vtex-apps/checkout-payment/pull/11.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
