### PR TITLE
CHUI-49: Add alert in case of error during place order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Display error alert in case of failure in the place order flow.
 
 ## [2.6.1] - 2020-06-29
 ### Changed

--- a/messages/en.json
+++ b/messages/en.json
@@ -2,5 +2,7 @@
   "store/place-order-button": "Place Order",
   "store/checkout-product-count": "{quantity, plural, one {# product} other {# products}}",
   "store/edit-cart-label": "Edit Cart",
-  "store/view-cart-label": "View Cart"
+  "store/view-cart-label": "View Cart",
+  "store/place-order.close-error-alert-label": "Close",
+  "store/place-order.generic-error-message": "The transaction can't be completed. Please try again soon."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -2,5 +2,7 @@
   "store/place-order-button": "Finalizar Compra",
   "store/checkout-product-count": "{quantity, plural, one {# producto} other {# productos}}",
   "store/edit-cart-label": "Editar Carrito",
-  "store/view-cart-label": "Ver Carrito"
+  "store/view-cart-label": "Ver Carrito",
+  "store/place-order.close-error-alert-label": "Cerca",
+  "store/place-order.generic-error-message": "La transacción no se pudo completar. Por favor, inténtelo de nuevo más tarde."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -2,5 +2,7 @@
   "store/place-order-button": "Fechar Pedido",
   "store/checkout-product-count": "{quantity, plural, one {# produto} other {# produtos}}",
   "store/edit-cart-label": "Editar Carrinho",
-  "store/view-cart-label": "Ver Carrinho"
+  "store/view-cart-label": "Ver Carrinho",
+  "store/place-order.close-error-alert-label": "Fechar",
+  "store/place-order.generic-error-message": "A transação não pôde ser completada. Por favor, tente novamente mais tarde."
 }

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 
 declare module 'vtex.styleguide' {
   export const Button: React.FC<{
@@ -6,4 +6,12 @@ declare module 'vtex.styleguide' {
     size?: 'large' | 'regular' | 'small'
     isLoading?: boolean
   } & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'className'>>
+
+  export const Alert: React.FC<{
+    type: 'error' | 'success' | 'warning'
+    closeIconLabel?: string
+    onClose?: () => void
+    focusOnEnter?: boolean
+    action?: { onClick: () => void; label: ReactNode }
+  }>
 }


### PR DESCRIPTION
#### What problem is this solving?

Adds an error alert when any request fail during the place order flow.

#### How should this be manually tested?

[Workspace](https://placefail--checkoutio.myvtex.com/cart/add?sku=289).

Test plan:

1. Enter the above workspace.
2. Go to checkout.
3. Enter a second purchase email.
4. Select payment with a new credit card and fill the required inputs.
5. In the review step, reload the page.
6. Press the place order button, you should see the error alert.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->