### PR TITLE
CHK-544: Update checkout orderForm route to include sub-routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated route for checkout orderForm route to include sub-routes.
 
 ## [2.8.0] - 2021-01-18
 ### Added

--- a/store/routes.json
+++ b/store/routes.json
@@ -6,7 +6,7 @@
     "path": "/cart/add/"
   },
   "store.checkout.order-form": {
-    "path": "/checkout"
+    "path": "/checkout/*splat"
   },
   "store.checkout.identification": {
     "path": "/checkout/identification"


### PR DESCRIPTION
#### What problem is this solving?

This will enable us to use React Router's `BrowserRouter` instead of `HashRouter`, which gives us the benefit of using `location.state` to store information we need to pass from one route to another.

Note that this doesn't change the behavior of using only `HashRouter`, this will just enable us to use the other router

#### How should this be manually tested?

[Workspace](https://addr--checkoutio.myvtex.com/cart/add?sku=289).

The `state` property is being used to send information about which address we will edit from the address step "back" to the shipping step (when you click the edit address button).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
