### PR TITLE
Rename orchestrators in docs to controllers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # VTEX Checkout
 
-## Orchestrators
+## Controllers
 
 ```
 store
@@ -47,7 +47,7 @@ All GraphQL queries and mutations used by Checkout IO are located in [`checkout-
 - [checkout-resources](https://github.com/vtex-apps/checkout-resources)
 - [address-context](https://github.com/vtex-apps/address-context)
 
-## Orchestrators
+## Controllers
 
 - [order-coupon](https://github.com/vtex-apps/order-coupon)
 - [order-items](https://github.com/vtex-apps/order-items)


### PR DESCRIPTION
#### What problem is this solving?

The motivation for this PR is that "orchestrators" isn't a well known term in the React community, even though it looks like it. It is confusing for new developers (specially developers that are also new to _React_ itself) to come across this term in our documentation and not find anything special about it when trying to search for it.

I've come across [this tweet](https://twitter.com/brian_d_vaughn/status/1131683016399417345) by a member of React core team which describes better what our "orchestrators" components are, and is more intuitive to think about, so that's why I'm proposing this change.

#### How should this be manually tested?

N/A

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

N/A

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
✔️ | Documentation

#### Notes

N/A
