### PR TITLE
[CHK-1139] Release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.0.0] - 2022-02-08
 ### Added
 - Proxy for fastcheckout server on `/checkout` and `/cart` routes.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "checkout",
-  "version": "2.9.0",
+  "version": "3.0.0",
   "title": "Checkout UI",
   "description": "Checkout UI for the Store Framework",
   "defaultLocale": "pt-BR",


### PR DESCRIPTION
The releases bot didn't generate a version tag because my previous PR didn't target the `main` branch :sweat\_smile:
