### PR TITLE
Update owner of checkout to te-0001

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -15,6 +15,6 @@ metadata:
 spec:
   type: backend-api
   lifecycle: experimental
-  owner: checkout-experience
+  owner: te-0001
   system: checkout
   dependsOn: []


### PR DESCRIPTION
This PR updates the owner of checkout to te-0001 in the catalog-info.yaml file.
This is necessary because now in DK Portal we will define the team -> component relationship through the team id instead of the owner name.